### PR TITLE
Allow any ssh user in remote

### DIFF
--- a/autoload/gitlab.vim
+++ b/autoload/gitlab.vim
@@ -67,17 +67,16 @@ function! gitlab#homepage_for_remote(remote) abort
         let domain_pattern .= '\|' . escape(pattern, '.')
     endfor
 
-    if !exists('g:fugitive_gitlab_ssh_user')
-        let g:fugitive_gitlab_ssh_user = 'git'
-    endif
-
+    " https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols
     " git://domain:path
     " https://domain/path
     " https://user@domain/path
-    " ssh://git@domain/path.git
-    " ssh://gitlab@domain/path.git
-    " ssh://git@domain:ssh_port/path.git
-    let base = matchstr(a:remote, '^\%(https\=://\|git://\|' . g:fugitive_gitlab_ssh_user . '@\|ssh://' . g:fugitive_gitlab_ssh_user . '@\)\%(.\{-\}@\)\=\zs\('.domain_pattern.'\)[/:].\{-\}\ze\%(\.git\)\=$')
+    " ssh://user@domain/path.git
+    " ssh://user@domain:ssh_port/path.git
+    " user@domain:path
+    let user_re = '[^/@]\+@'
+    let domain_match = '^\%(https\=://\|git://\|' . user_re . '\|ssh://' . user_re . '\)\%(.\{-\}@\)\=\zs\(' . domain_pattern . '\)[/:].\{-\}\ze\%(\.git\)\=$'
+    let base = matchstr(a:remote, domain_match)
 
     " Remove port
     let base = substitute(base, ':\d\{1,5}\/', '/', '')

--- a/test/gbrowse.vader
+++ b/test/gbrowse.vader
@@ -1,11 +1,9 @@
 Before:
     Save g:fugitive_gitlab_domains
     Save g:fugitive_browse_handlers
-    Save g:fugitive_gitlab_ssh_user
 
     unlet! g:fugitive_browse_handlers
     unlet! g:fugitive_gitlab_domains
-    unlet! g:fugitive_gitlab_ssh_user
 
     unlet! g:loaded_fugitive_gitlab
     unlet! g:autoloaded_fugitive_gitlab
@@ -101,7 +99,7 @@ Execute (Gbrowse - https remote with @):
 
 Execute (Gbrowse - Long form ssh remote):
     let opts = {
-      \'remote': 'ssh://git@gitlab.com:shumphrey/fugitive-gitlab.vim.git',
+      \'remote': 'ssh://git@gitlab.com/shumphrey/fugitive-gitlab.vim.git',
       \'commit': 'master',
       \'type': 'blob',
       \'path': 'myfile.vim'
@@ -112,16 +110,11 @@ Execute (Gbrowse - Long form ssh remote):
 
 Execute (Gbrowse - Long form ssh remote with non-standard ssh user):
     let opts = {
-      \'remote': 'ssh://gitlab@gitlab.com:shumphrey/fugitive-gitlab.vim.git',
+      \'remote': 'ssh://gitlab@gitlab.com/shumphrey/fugitive-gitlab.vim.git',
       \'commit': 'master',
       \'type': 'blob',
       \'path': 'myfile.vim'
     \}
-
-    let url = g:fugitive_browse_handlers[0](opts)
-    AssertEqual '', url
-
-    let g:fugitive_gitlab_ssh_user = 'gitlab'
     let url = g:fugitive_browse_handlers[0](opts)
 
     AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/blob/master/myfile.vim', url
@@ -144,11 +137,6 @@ Execute (Gbrowse - Short form ssh remote with non-standard ssh user):
       \'type': 'blob',
       \'path': 'myfile.vim'
     \}
-
-    let url = g:fugitive_browse_handlers[0](opts)
-    AssertEqual '', url
-
-    let g:fugitive_gitlab_ssh_user = 'gitlab'
     let url = g:fugitive_browse_handlers[0](opts)
 
     AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/blob/master/myfile.vim', url

--- a/test/homepage_for_remote.vader
+++ b/test/homepage_for_remote.vader
@@ -27,6 +27,25 @@ Execute (gitlab#homepage_for_remote - https://user@ url):
     let expected = 'https://my.gitlab.com/shumphrey/fugitive-gitlab.vim'
     let url = gitlab#homepage_for_remote('https://shumphrey@my.gitlab.com/shumphrey/fugitive-gitlab.vim.git')
     AssertEqual url, expected
+    let url = gitlab#homepage_for_remote('https://shumphrey:mypassword@my.gitlab.com/shumphrey/fugitive-gitlab.vim.git')
+    AssertEqual url, expected
+    let url = gitlab#homepage_for_remote('https://shumphrey:mypassword@my.gitlab.com:5000/shumphrey/fugitive-gitlab.vim.git')
+    AssertEqual url, expected
+
+Execute (gitlab@homepage_for_remote - ssh://user@ url):
+    let expected = 'https://my.gitlab.com/shumphrey/fugitive-gitlab.vim'
+    let url = gitlab#homepage_for_remote('ssh://myrandomuser@my.gitlab.com/shumphrey/fugitive-gitlab.vim.git')
+    AssertEqual url, expected
+    let url = gitlab#homepage_for_remote('ssh://myrandomuser:mypassword@my.gitlab.com/shumphrey/fugitive-gitlab.vim.git')
+    AssertEqual url, expected
+    let url = gitlab#homepage_for_remote('ssh://myrandomuser:mypassword@my.gitlab.com:5000/shumphrey/fugitive-gitlab.vim.git')
+    AssertEqual url, expected
+
+Execute (gitlab#homepage_for_remote - user@domain:path url):
+    let url = gitlab#homepage_for_remote('randomuser@my.gitlab.com:shumphrey/fugitive-gitlab.vim.git')
+    AssertEqual url, expected
+    let url = gitlab#homepage_for_remote('randomuser:randompassword@my.gitlab.com:shumphrey/fugitive-gitlab.vim.git')
+    AssertEqual url, expected
 
 Execute (gitlab#homepage_for_remote - gitlab.com):
     unlet g:fugitive_gitlab_domains


### PR DESCRIPTION
This changes the allowable ssh users from being specified by a variable
to not needing to be specified at all.

We don't actually use the ssh user for anything other than matching
domains. So instead, we change the regex to allow most strings as
a user.

Closes #30