### PR TITLE
Skip omnifunc setup when GitLab API key is not available

### DIFF
--- a/plugin/gitlab.vim
+++ b/plugin/gitlab.vim
@@ -33,6 +33,8 @@ augroup gitlab
   autocmd!
   autocmd User Fugitive
         \ if expand('%:p') =~# '\.git[\/].*MSG$' &&
+        \   exists('g:gitlab_api_keys') &&
+        \   !empty(g:gitlab_api_keys) &&
         \   exists('+omnifunc') &&
         \   &omnifunc =~# '^\%(syntaxcomplete#Complete\)\=$' &&
         \   !empty(gitlab#homepage_for_remote(FugitiveRemoteUrl())) |


### PR DESCRIPTION
I'm not using the omnifunc and since my GitLab is in a different
country, this slows down Vim quite a bit when I `:Git commit` or
`git commit` (I'm using Vim as Git's editor).

Since the omnifunc doesn't work without the API keys, I think we can
skip its setup in this case.
