### PR TITLE
Update README for configuring different URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ To use private GitLab instances, add the following to your .vimrc
 
     let g:fugitive_gitlab_domains = ['https://my.gitlab.com']
 
+If the private GitLab instance uses different URLs, for example, one for SSH
+and another for HTTPS, instead add the following to your .vimrc
+
+    let g:fugitive_gitlab_domains = {'ssh://my-ssh.gitlab.com': 'https://my.gitlab.com'}
+
 Fugitive command `:GBrowse` will now work with GitLab URLs.
 
 [Curl](http://curl.haxx.se/) is required for features

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ private GitLab instance.
 Install it as you would install [fugitive.vim][]
 (you will also need [fugitive.vim][] installed)
 
-To use private GitLab repositories add the following to your .vimrc
+To use private GitLab instances, add the following to your .vimrc
 
     let g:fugitive_gitlab_domains = ['https://my.gitlab.com']
 


### PR DESCRIPTION
This pull request updates the README for the changes made in https://github.com/shumphrey/fugitive-gitlab.vim/commit/25a0be4ee219e2555de13f7836df1192368ec572.

Most importantly, this pull request adds to the README an instruction on how to configure for a private GitLab instance that uses different SSH and HTTPS URLs.

Refs: https://github.com/shumphrey/fugitive-gitlab.vim/issues/34