### PR TITLE
Fix URL format for modern GitLab

### DIFF
--- a/autoload/gitlab/fugitive.vim
+++ b/autoload/gitlab/fugitive.vim
@@ -14,6 +14,10 @@ function! gitlab#fugitive#handler(opts, ...)
         return ''
     endif
 
+    if !exists('g:fugitive_gitlab_oldstyle_urls')
+        let root = root . '/-'
+    endif
+
     " work out what branch/commit/tag/etc we're on
     " if file is a git/ref, we can go to a /commits gitlab url
     " If the branch/tag doesn't exist upstream, the URL won't be valid
@@ -30,8 +34,9 @@ function! gitlab#fugitive#handler(opts, ...)
 
     let commit = a:opts.commit
 
-    " If buffer contains directory not file, return a /tree url
+    " All paths re-verified with gitlab.com on 22-05-2023
     let path = get(a:opts, 'path', '')
+    " If buffer contains directory not file, return a /tree url
     if get(a:opts, 'type', '') ==# 'tree' || get(a:opts, 'path', '') =~# '/$'
         let url = substitute(root . '/tree/' . commit . '/' . path,'/$','', '')
     elseif get(a:opts, 'type', '') ==# 'blob' || path =~# '[^/]$'

--- a/test/gbrowse.vader
+++ b/test/gbrowse.vader
@@ -25,7 +25,7 @@ Execute (GBrowse - blob):
     \}
     let url = g:fugitive_browse_handlers[0](opts)
 
-    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/blob/master/myfile.vim', url
+    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/-/blob/master/myfile.vim', url
 
 Execute (GBrowse - blob with range):
     let opts = {
@@ -38,7 +38,7 @@ Execute (GBrowse - blob with range):
     \}
     let url = g:fugitive_browse_handlers[0](opts)
 
-    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/blob/a935a734765575b33da6c50fe8d0175e70e0e542/myfile.vim#L1-3', url
+    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/-/blob/a935a734765575b33da6c50fe8d0175e70e0e542/myfile.vim#L1-3', url
 
 Execute (GBrowse - directory tree):
     let opts = {
@@ -48,7 +48,7 @@ Execute (GBrowse - directory tree):
       \'path': 'path1/path2'
     \}
     let url = g:fugitive_browse_handlers[0](opts)
-    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/tree/master/path1/path2', url
+    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/-/tree/master/path1/path2', url
 
 Execute (GBrowse - commit type):
     let opts = {
@@ -57,7 +57,7 @@ Execute (GBrowse - commit type):
       \'type': 'commit',
     \}
     let url = g:fugitive_browse_handlers[0](opts)
-    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/commit/a935a734765575b33da6c50fe8d0175e70e0e542', url
+    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/-/commit/a935a734765575b33da6c50fe8d0175e70e0e542', url
 
 Execute (GBrowse - private ssh remote):
     let opts = {
@@ -73,7 +73,7 @@ Execute (GBrowse - private ssh remote):
     let g:fugitive_gitlab_domains = ['https://my.gitlab.com']
     let url = g:fugitive_browse_handlers[0](opts)
 
-    AssertEqual 'https://my.gitlab.com/shumphrey/fugitive-gitlab.vim/blob/master/myfile.vim', url
+    AssertEqual 'https://my.gitlab.com/shumphrey/fugitive-gitlab.vim/-/blob/master/myfile.vim', url
 
     unlet g:fugitive_gitlab_domains
 
@@ -86,7 +86,7 @@ Execute (GBrowse - https remote):
     \}
     let url = g:fugitive_browse_handlers[0](opts)
 
-    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/blob/master/myfile.vim', url
+    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/-/blob/master/myfile.vim', url
 
 Execute (GBrowse - https remote with @):
     let opts = {
@@ -97,7 +97,7 @@ Execute (GBrowse - https remote with @):
     \}
     let url = g:fugitive_browse_handlers[0](opts)
 
-    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/blob/master/myfile.vim', url
+    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/-/blob/master/myfile.vim', url
 
 Execute (GBrowse - Long form ssh remote):
     let opts = {
@@ -108,7 +108,7 @@ Execute (GBrowse - Long form ssh remote):
     \}
     let url = g:fugitive_browse_handlers[0](opts)
 
-    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/blob/master/myfile.vim', url
+    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/-/blob/master/myfile.vim', url
 
 Execute (GBrowse - Long form ssh remote with non-standard ssh user):
     let opts = {
@@ -119,7 +119,7 @@ Execute (GBrowse - Long form ssh remote with non-standard ssh user):
     \}
     let url = g:fugitive_browse_handlers[0](opts)
 
-    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/blob/master/myfile.vim', url
+    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/-/blob/master/myfile.vim', url
 
 Execute (GBrowse - Long form ssh remote with non-standard port):
     let opts = {
@@ -130,7 +130,7 @@ Execute (GBrowse - Long form ssh remote with non-standard port):
     \}
     let url = g:fugitive_browse_handlers[0](opts)
 
-    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/blob/master/myfile.vim', url
+    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/-/blob/master/myfile.vim', url
 
 Execute (GBrowse - Short form ssh remote with non-standard ssh user):
     let opts = {
@@ -141,7 +141,7 @@ Execute (GBrowse - Short form ssh remote with non-standard ssh user):
     \}
     let url = g:fugitive_browse_handlers[0](opts)
 
-    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/blob/master/myfile.vim', url
+    AssertEqual 'https://gitlab.com/shumphrey/fugitive-gitlab.vim/-/blob/master/myfile.vim', url
 
 Execute (GBrowse - Does not match non-gitlab remote):
     let opts = {


### PR DESCRIPTION
Fix URL format for modern GitLab
At some point in the past, GitLab changed its URL format to contain a hyphen/dash
e.g.
gitlab.com/org/project/-/blob/<sha>
instead of gitlab.com/org/project/blob/<sha>

For most URLs, GitLab redirects you to the hyphen version.
For /commit there is no redirect so the :GBrowse link is broken.

GitLab's change is documented here:
https://gitlab.com/gitlab-org/gitlab/-/issues/214217

I've changed all the URLs to this new format.
This suggests that it might break for people on older self-hosted GitLab versions.
I think supporting gitlab.com is probably my priority, but I've added a get out clause.

if a user specifies a `let g:fugitive_gitlab_oldstyle_urls = 1` in their vimrc, they'll get the old behaviour.

Fixes #43