### PR TITLE
Support git+ssh:// URL

### DIFF
--- a/autoload/gitlab/fugitive.vim
+++ b/autoload/gitlab/fugitive.vim
@@ -59,7 +59,7 @@ function! gitlab#fugitive#homepage_for_remote(url) abort
     " https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols
     " [full_url, scheme, host_with_port, host, path]
     if a:url =~# '://'
-        let match = matchlist(a:url, '^\(https\=://\|git://\|ssh://\)\%([^@/]\+@\)\=\(\([^/:]\+\)\%(:\d\+\)\=\)/\(.\{-\}\)\%(\.git\)\=/\=$')
+        let match = matchlist(a:url, '^\(https\=://\|git://\|ssh://\|git+ssh://\)\%([^@/]\+@\)\=\(\([^/:]\+\)\%(:\d\+\)\=\)/\(.\{-\}\)\%(\.git\)\=/\=$')
     else
         let match = matchlist(a:url, '^\([^@/]\+@\)\=\(\([^:/]\+\)\):\(.\{-\}\)\%(\.git\)\=/\=$')
         if empty(match)

--- a/test/homepage_for_remote.vader
+++ b/test/homepage_for_remote.vader
@@ -117,3 +117,19 @@ Execute (gitlab#fugitive#homepage_for_remote - verbose ssh:// with user and port
     let expected = 'https://my.gitlab.com:3456/shumphrey/fugitive-gitlab.vim'
     let url = gitlab#fugitive#homepage_for_remote('ssh://git@my.gitlab.com:12345/shumphrey/fugitive-gitlab.vim.git')
     AssertEqual url, expected
+
+Execute (gitlab#fugitive#homepage_for_remote - git+ssh://):
+    let g:fugitive_gitlab_domains = {
+      \   'git+ssh://my.gitlab.com': 'https://my.gitlab.com',
+      \ }
+    let expected = 'https://my.gitlab.com/shumphrey/fugitive-gitlab.vim'
+    let url = gitlab#fugitive#homepage_for_remote('git+ssh://my.gitlab.com/shumphrey/fugitive-gitlab.vim.git')
+    AssertEqual url, expected
+
+Execute (gitlab#fugitive#homepage_for_remote - git+ssh:// with user and port):
+    let g:fugitive_gitlab_domains = {
+      \   'git+ssh://git@my.gitlab.com:12345': 'https://my.gitlab.com:3456',
+      \ }
+    let expected = 'https://my.gitlab.com:3456/shumphrey/fugitive-gitlab.vim'
+    let url = gitlab#fugitive#homepage_for_remote('git+ssh://git@my.gitlab.com:12345/shumphrey/fugitive-gitlab.vim.git')
+    AssertEqual url, expected


### PR DESCRIPTION
For reasons I don't fully understand, my company uses remote URLs like `git+ssh://user@gitlab.server.com/repo` which Git and vim-fugitive are perfectly happy with, but this plugin does not recognise.

All is well with this patch.